### PR TITLE
Backport passing native project in hook context

### DIFF
--- a/bin/templates/scripts/cordova/Api.js
+++ b/bin/templates/scripts/cordova/Api.js
@@ -74,6 +74,8 @@ function Api(platform, platformRootDir, events) {
         cordovaJs: 'bin/CordovaLib/cordova.js',
         cordovaJsSrc: 'bin/cordova-js-src'
     };
+
+    this._handler = require('./lib/projectFile');
 }
 
 /**

--- a/bin/templates/scripts/cordova/lib/projectFile.js
+++ b/bin/templates/scripts/cordova/lib/projectFile.js
@@ -92,6 +92,19 @@ function purgeProjectFileCache(project_dir) {
 
 module.exports = {
     parse: parseProjectFile,
+    parseProjectFile: function(project_dir) {
+        if (!project_dir || !fs.existsSync(project_dir)) {
+            throw new Error(`"${project_dir}" is not a valid project directory.`);
+        }
+
+        var xcodeProjPath = fs.readdirSync(project_dir).filter(function (file) { return ~file.indexOf('.xcodeproj') && fs.statSync(path.join(project_dir, file)).isDirectory(); })[0];
+        if (!xcodeProjPath) {
+            throw new Error(`Path "${project_dir}" doesn't contain an Xcode project.`);
+        }
+
+        var pbxPath = path.join(xcodeProjPath, "project.pbxproject");
+        return parseProjectFile({ root: project_dir, pbxproj: pbxPath });
+    },
     purgeProjectFileCache: purgeProjectFileCache
 };
 


### PR DESCRIPTION
Some ot the Telerik Verified plugins' hooks expect a property in the passed context, containing the native project. This is a result of the combination between [this PR](https://github.com/Icenium/cordova-lib/pull/2) and [this commit](https://github.com/Icenium/cordova-lib/commit/d98d7a2da32d0910ce8f7cb4465b90a9b0735484), which combined enable the plugman to pass a single instance ot the native project to all of the installed plugins.
This change is necessary, due to the fact that cordova's plugman uses the platform's Api from within the platform if available and if not - a PlatformApiPoly file within the plugman, which serves as a polyfill. Up until now we've worked with the polyfill because none of the platforms exposed their own Api. In cordova-ios 4.0.0 such an Api was introduced and plugman started using it instead of the polyfill.

Fixes [The plugman we use for cordova 5.0.0 doesn't pass correct parameters when executing hooks](http://teampulse.telerik.com/view#item/317313)

Ping @mbektchiev @galexandrov and anyone else from @Icenium/core who wants to take a look
