### PR TITLE
Fix project.pbxproj file name and edit the xcode dependency to be backwards compatible.

### DIFF
--- a/bin/node_modules/xcode/lib/pbxProject.js
+++ b/bin/node_modules/xcode/lib/pbxProject.js
@@ -790,6 +790,11 @@ pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
 }
 
+// Keep this for backwards compatibility.
+pbxProject.prototype.pbxNativeTarget = function() {
+    return this.pbxNativeTargetSection();
+}
+
 pbxProject.prototype.pbxXCConfigurationList = function() {
     return this.hash.project.objects['XCConfigurationList'];
 }
@@ -1114,22 +1119,22 @@ pbxProject.prototype.addTarget = function(name, type, subfolder) {
         targetType = type,
         targetSubfolder = subfolder || name,
         targetName = name.trim();
-        
+
     // Check type against list of allowed target types
     if (!targetName) {
         throw new Error("Target name missing.");
-    }    
+    }
 
     // Check type against list of allowed target types
     if (!targetType) {
         throw new Error("Target type missing.");
-    } 
+    }
 
     // Check type against list of allowed target types
     if (!producttypeForTargettype(targetType)) {
         throw new Error("Target type invalid: " + targetType);
     }
-    
+
     // Build Configuration: Create
     var buildConfigurationsList = [
         {

--- a/bin/templates/scripts/cordova/lib/projectFile.js
+++ b/bin/templates/scripts/cordova/lib/projectFile.js
@@ -102,7 +102,7 @@ module.exports = {
             throw new Error(`Path "${project_dir}" doesn't contain an Xcode project.`);
         }
 
-        var pbxPath = path.join(xcodeProjPath, "project.pbxproject");
+        var pbxPath = path.join(xcodeProjPath, "project.pbxproj");
         return parseProjectFile({ root: project_dir, pbxproj: pbxPath });
     },
     purgeProjectFileCache: purgeProjectFileCache


### PR DESCRIPTION
When we parse the project file in parseProjectFile we should pass `project.pbxproj` instead of `project.pbxproject`.

Also since there is a breaking change in the xcode dependency - `pbxNativeTarget` is renamed to `pbxNativeTargetSection` we should edit our local copy to be backwards compatible by adding `pbxNativeTarget` method.
