### PR TITLE
Fix project.pbxproj file name and edit the xcode dependency to be backwards compatible.

### DIFF
--- a/bin/templates/scripts/cordova/lib/projectFile.js
+++ b/bin/templates/scripts/cordova/lib/projectFile.js
@@ -109,7 +109,7 @@ module.exports = {
             throw new Error(`Path "${project_dir}" doesn't contain an Xcode project.`);
         }
 
-        var pbxPath = path.join(xcodeProjPath, "project.pbxproject");
+        var pbxPath = path.join(xcodeProjPath, "project.pbxproj");
         return parseProjectFile({ root: project_dir, pbxproj: pbxPath });
     },
     purgeProjectFileCache: purgeProjectFileCache

--- a/node_modules/xcode/lib/pbxProject.js
+++ b/node_modules/xcode/lib/pbxProject.js
@@ -230,7 +230,7 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
         file = this.addPluginFile(path, opt);
         if (!file) return false;
     } else {
-        file = new pbxFile(path, opt);       
+        file = new pbxFile(path, opt);
         if (this.hasFile(file.path)) return false;
     }
 
@@ -241,10 +241,10 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
         correctForResourcesPath(file, this);
         file.fileRef = this.generateUuid();
     }
-    
+
     this.addToPbxBuildFileSection(file);        // PBXBuildFile
     this.addToPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
-    
+
     if (!opt.plugin) {
         this.addToPbxFileReferenceSection(file);    // PBXFileReference
         if (group) {
@@ -253,9 +253,9 @@ pbxProject.prototype.addResourceFile = function(path, opt, group) {
         else {
             this.addToResourcesPbxGroup(file);          // PBXGroup
         }
-        
+
     }
-    
+
     return file;
 }
 
@@ -279,7 +279,7 @@ pbxProject.prototype.removeResourceFile = function(path, opt, group) {
     }
     else {
         this.removeFromResourcesPbxGroup(file);          // PBXGroup
-    }    
+    }
     this.removeFromPbxResourcesBuildPhase(file);     // PBXResourcesBuildPhase
 
     return file;
@@ -909,6 +909,11 @@ pbxProject.prototype.pbxFileReferenceSection = function() {
 
 pbxProject.prototype.pbxNativeTargetSection = function() {
     return this.hash.project.objects['PBXNativeTarget'];
+}
+
+// Keep this for backwards compatibility.
+pbxProject.prototype.pbxNativeTarget = function() {
+    return this.pbxNativeTargetSection();
 }
 
 pbxProject.prototype.xcVersionGroupSection = function () {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "plist": "^1.2.0",
     "q": "^1.4.1",
     "shelljs": "^0.5.3",
-    "xcode": "^0.8.5"
+    "xcode": "https://github.com/Icenium/node-xcode/tarball/26fceb1b8bd907ced23d626a3e9eb5c8eeff9dcf"
   },
   "bundledDependencies": [
     "cordova-common",


### PR DESCRIPTION
When we parse the project file in parseProjectFile we should pass `project.pbxproj` instead of `project.pbxproject`.

Also since there is a breaking change in the xcode dependency - `pbxNativeTarget` is renamed to `pbxNativeTargetSection` we should edit our local copy to be backwards compatible by adding `pbxNativeTarget` method.
